### PR TITLE
fixed some errors due to variable name typos and incorrect ranges

### DIFF
--- a/R/BumpBetaMatrix.R
+++ b/R/BumpBetaMatrix.R
@@ -14,10 +14,10 @@ get_betas <- function(bump, dataset) {
 		stop("Argument 'dataset' must be a 'GenomicRatioSet' or an 'ExpressionSet'")
 	}
 	# Extract the beta values
-	if(type == 1) {
-		betas <- minfi::getBeta(set[bump$indexStart:bump$indexEnd, ]) 
+	if(data_type == 1) {
+		betas <- minfi::getBeta(dataset[bump$indexStart:bump$indexEnd, ]) 
 	} else {
-		betas <- Biobase::exprs(set[bump$indexStart:bump$indexEnd, ])
+		betas <- Biobase::exprs(dataset[bump$indexStart:bump$indexEnd, ])
 	}
 	# Remove NAs
 	betas <- na.omit(betas)

--- a/R/EpiMutations.R
+++ b/R/EpiMutations.R
@@ -92,7 +92,7 @@ EpiMutations<-function(cases, controls, num.cpgs = 10, pValue.cutoff = 0.01,
     #Find beta value matrix for each bump
     
     #Outlier identification using multiple statistical approach 
-    for(i in 1:nrow(bumps)) {
+    for(i in seq_len(nrow(bumps))) {
       #Find beta value matrix for each bump
       beta.values <- get_betas(bumps[i, ], set)
       #manova


### PR DESCRIPTION
Fixed some errors. The code below still doesn't run though

```
load("../epimutacions-datasets/case_dataset.Rdata")
load("../epimutacions-datasets/control_dataset.Rdata")

epi <- EpiMutations(cases[1:1000, 2], controls[1:1000,], num.cpgs = 1, method = "manova")
```
Gives the following error:
`Error in manova(beta.values ~ model[, 2]) : need multiple responses`

Also fails with `method="mlm"`: `Error in mlm::mlm(beta.values ~ model[, 2]) : 
  The number of response variables should be >= 2.`

