### PR TITLE
Task1ab feature cases as controls

### DIFF
--- a/R/EpiMutations.R
+++ b/R/EpiMutations.R
@@ -1,146 +1,143 @@
 #' @export
-EpiMutations<-function(cases, controls, num.cpgs = 10, pValue.cutoff = 0.01, 
-                       cutoff =0.1, outlier.score = 0.5, 
-                       nsamp = "deterministic",method = "manova")
-{
+EpiMutations <- function(
+  cases,
+  controls,
+  num.cpgs = 10,
+  pValue.cutoff = 0.01,
+  cutoff = 0.1,
+  outlier.score = 0.5,
+  nsamp = "deterministic",
+  method = c("manova", "mlm", "iso.forest", "Mahdist.MCD")
+) {
   
-  #Correct parameter verification
+  check_params(cases, controls, method)
+
+  set <- set_concat(cases, controls)
   
-  if(is.null(cases))
-  {
+  model <- make_bumphunter_model(set, sample_id=colnames(cases))
+  bumps <- run_bumphunter(set, model, cutoff)
+  
+  check_bumps(bumps)
+  bumps <- filter_bumps(bumps, min_cpgs_per_bump=num.cpgs)
+  
+  bumps <- compute_bump_outlier_scores(set, bumps, method, colnames(cases), model, nsamp)
+  bumps <- select_outlier_bumps(bumps, method, pValue.cutoff, outlier.score)
+  
+  return(format_bumps(bumps, colnames(cases)))
+}
+
+check_params <- function(cases, controls, method){
+  if(is.null(cases)) {
     stop("'Diseases' parameter must be introduced")
   }
-  
-  #Diseases length(diseases) ==1
-  num_cases <- ncol(cases)
-  num_controls <- ncol(controls)
-  
-  if(num_cases != 1) {
+  if(ncol(cases) != 1) {
     stop('Number of cases has to be one')
   }
-  
-  if(num_controls < 2) {
+  if(ncol(controls) < 2) {
     stop('Number of samples in controls (aka.reference panel) must be greater than 2')
   }
-  
   if(length(method) !=1) {
     stop('Only one "method" can be chosen at a time')
   }
-  
-  #dataset type (GenomicRatioSet or ExpressionSet)
   type <- charmatch(class(cases), c("GenomicRatioSet", "ExpressionSet"))
-  
   if(is.na(type)) {
     stop("The data type must be 'GenomicRatioSet' or 'ExpressionSet'")  
   }
-  
-  #Select one of the available methods
-  
   selected_method <- charmatch(method, c("manova", "mlm", "iso.forest", "Mahdist.MCD"))
-  
   if(is.na(selected_method)) {
     stop("The selected method must be 'manova', 'mlm','iso.forest','Mahdist.MCD'")  
   }
-  
-  
-  #Combine control panel with the disease sample
-  if(type == 1) { # GenomicRatioSets
-    set <- minfi::combineArrays(controls, cases,
-                                outType = c("IlluminaHumanMethylation450k",
-                                            "IlluminaHumanMethylationEPIC",
-                                            "IlluminaHumanMethylation27k"),
-                                verbose = TRUE)
-  } else if (type == 2) { #ExpressionSet
-    set <- a4Base::combineTwoExpressionSet(es.control.panel,
-                                           diseases)
-    exprs.mat<-Biobase::exprs(set)
-    fdata<-Biobase::fData(set)
+}
+
+set_concat <- function(cases, controls){
+  if(class(cases) == "GenomicRatioSet") {
+    return(minfi::combineArrays(
+      controls, cases,
+      outType = c("IlluminaHumanMethylation450k",
+        "IlluminaHumanMethylationEPIC",
+        "IlluminaHumanMethylation27k"),
+        verbose = TRUE)
+      )
+  } else if (class(cases) == "ExpressionSet") {
+    return(a4Base::combineTwoExpressionSet(controls, cases))
   }
-  
-  #Obtain Phenotypic data  
-  pdata <- Biobase::pData(set)
-  sample <- colnames(cases)
-  
-  #create a variable 0,0,0,0...0,0,1  
-  pdata$samp <- pdata$sampleID == sample
-  
-  #Create the model matrix
-  model <- stats::model.matrix(~samp, pdata)
-  
-  #Bumphunter function from bumphunter package
-  #GenomicRatioSet    
-  if(type == 1) {
-    bumps <- bumphunter::bumphunter(set, model, cutoff = 0.1)$table
-  } else if (type == 2) { #ExpressionSet 
-    bumps <- bumphunter::bumphunter(object = exprs.mat,
-                                    design = model,
-                                    pos = fdata$RANGE_START,
-                                    chr = fdata$CHR,
-                                    cutoff = 0.1)$table
+}
+
+make_bumphunter_model <- function(set, sample_id){
+  # model over samples is 0,0,0,0...0,0,1
+  Biobase::pData(set)$samp <- Biobase::pData(set)$sampleID == sample_id
+  return(stats::model.matrix(~samp, Biobase::pData(set)))
+}
+
+run_bumphunter <- function(set, model, cutoff){
+  if(class(set) == "GenomicRatioSet") {
+    return(bumphunter::bumphunter(set, model, cutoff = cutoff)$table)
+  } else if (class(set) == "ExpressionSet") {
+    return(
+      bumphunter::bumphunter(
+        object = Biobase::exprs(set),
+        design = model,
+        pos = Biobase::fData(set)$RANGE_START,
+        chr = Biobase::fData(set)$CHR,
+        cutoff = cutoff)
+      $table
+    )
   }
+}
+
+check_bumps <- function(bumps){
+  if(is.na(bumps[1,1])) {
+    stop("Bumhunter has returned NAs.")
+  }
+}
+
+filter_bumps <- function(bumps, min_cpgs_per_bump){
+  bumps <- subset(bumps, L >= min_cpgs_per_bump)
+  return(bumps)
+}
+
+compute_bump_outlier_scores <- function(set, bumps, method, sample, model, nsamp){
   
-  #Outlier identification using multiple methods
-  
-  if(!is.na(bumps[1,1]))
-  {
-    
-    bumps$sample <- sample
-    
-    #delect bumps with at least selected "num.cpgs"
-    bumps <- subset(bumps, L >= num.cpgs)
-    
-    #Find beta value matrix for each bump
-    
-    #Outlier identification using multiple statistical approach 
-    for(i in seq_len(nrow(bumps))) {
-      #Find beta value matrix for each bump
-      beta.values <- get_betas(bumps[i, ], set)
-      #manova
-      if(method == "manova")
-      {
-        if(ncol(beta.values) > nrow(beta.values) - 2 ) {
-          stop("Not enoght samples to run MANOVA")
-        } else {
-          bumps$manova[i]<-EpiMANOVA(beta.values, model)
-        }
+  for(i in seq_len(nrow(bumps))) {
+    beta.values <- get_betas(bumps[i, ], set)
+    if(method == "manova") {
+      if(ncol(beta.values) > nrow(beta.values) - 2 ) {
+        stop("Not enough samples to run MANOVA")
       }
-      #mlm
-      if(method == "mlm")
-      {
-        bumps$mlm[i]<-epiMLM(beta.values,model)  
-      }
-      if(method == "iso.forest")
-      {
-        bumps$iso[i]<-epiIsolationForest(beta.values, sample)
-        
-      }
-      if(method == "Mahdist.MCD")
-      {
-        bumps$MahMCD[i]<-epiMahdist.MCD(beta.values, nsamp, sample)
-      }
+      bumps$manova[i]<-EpiMANOVA(beta.values, model)
     }
-    
-    #Subset bumps using p value
-    
-    if(method == "manova")
-    {
-      outliers.epi.mutations <- subset(bumps, manova < pValue.cutoff)
+    if(method == "mlm") {
+      bumps$mlm[i]<-epiMLM(beta.values, model)  
     }
-    if(method == "mlm")
-    {
-      outliers.epi.mutations <- subset(bumps, mlm < pValue.cutoff)
+    if(method == "iso.forest") {
+      bumps$iso[i]<-epiIsolationForest(beta.values, sample)
     }
-    if(method == "iso.forest")
-    {
-      outliers.epi.mutations <- subset(bumps, iso > outlier.score)
-      
-    }
-    if(method == "Mahdist.MCD")
-    {
-      outliers.epi.mutations <- subset(bumps, MahMCD == TRUE)
+    if(method == "Mahdist.MCD") {
+      bumps$MahMCD[i]<-epiMahdist.MCD(beta.values, nsamp, sample)
     }
   }
+  return(bumps)
+}
+
+select_outlier_bumps <- function(bumps, method, pValue.cutoff, outlier.score){
+
+  if(method == "manova"){
+    outliers <- subset(bumps, manova < pValue.cutoff)
+  }
+  if(method == "mlm"){
+    outliers <- subset(bumps, mlm < pValue.cutoff)
+  }
+  if(method == "iso.forest"){
+    outliers <- subset(bumps, iso > outlier.score)
+  }
+  if(method == "Mahdist.MCD"){
+    outliers <- subset(bumps, MahMCD == TRUE)
+  }
   
-  outliers.epi.mutations<-tibble::as_tibble(outliers.epi.mutations)
-  return(outliers.epi.mutations)
+  return(outliers)
+}
+
+format_bumps <- function(bumps, sample){
+  bumps$sample <- sample
+  return(tibble::as_tibble(bumps))
 }


### PR DESCRIPTION
Added two arguments to `EpiMutations()`:
`sample_id` (str): The colname in `case` to compute epimutations on.
`cases_as_controls` (bool): Should remaining cases be used as controls?

Proposed solution involves the following:

- Before concatenating cases and controls, add an "origin" column in pData which equals "case" or "control". This marks each sample's origin.
- Concatenate cases and controls into a single set.
- If cases_as_control is False, keep only columns in set where origin="control" or colname="sample_id".
- If cases_as_control is True, do not remove anything. The remaining cases are automatically considered as controls in the downstream code.