### PR TITLE
Task1 test all methods return toy epimutation

### DIFF
--- a/R/epiMahdist.MCD.R
+++ b/R/epiMahdist.MCD.R
@@ -1,17 +1,18 @@
 #' Epimutation detection based on Outlier Detection with Robust Mahalanobis
 #' 
 #' The implementation of the method here is based on the discusion in this
-#' thred of StakOverflow:
+#' thread of StakOverflow:
 #' https://stats.stackexchange.com/questions/137263/multivariate-outlier-detection-with-robust-mahalanobis
 #' 
 #' @param betas matrix A matrix with the beta values of controls with a single 
 #' case (proband) to be tested for outlier with CpGs as rows and samples 
 #' (controls + 1 case ) as columns.
 #' @param nsamp character/integer Number of subsets used for initial estimates.
-#' It can take a stratgey ("best", "exact", or "deterministic") or an exact
+#' It can take a strategy ("best", "exact", or "deterministic") or an exact
 #' number.
+#' @param sample (string) The sample column name in betas to run the outlier detection on. 
 #' @export
-epiMahdist.MCD <- function(betas, nsamp = c("best", "exact", "deterministic")) {
+epiMahdist.MCD <- function(betas, nsamp = c("best", "exact", "deterministic"), sample) {
 	if(is.null(betas)) {
 		stop("'betas' data frame must be introduced")
 	}

--- a/tests/testthat/test_epimutations.R
+++ b/tests/testthat/test_epimutations.R
@@ -43,8 +43,17 @@ test_that("returns zero rows if bumphunter finds no bumps", {
 	expect_equal(actual, 0)
 })
 
-test_that("returns with toy genomicratioset", {
+test_that("returns >= 1 epimutation with toy genomicratioset and method manova", {
 	data("genomicratioset")
-	out <- epimutations(cases = genomicratioset, num.cpgs = 3, method = "iso.forest")
-	expect_equal(nrow(out), 0)
+	out <- epimutations(cases = genomicratioset, method = "manova")
+	out <- epimutations(cases = genomicratioset, method = "mlm")
+	out <- epimutations(cases = genomicratioset, method = "iso.forest")
+	out <- epimutations(cases = genomicratioset, method = "Mahdist.MCD")
+	expect_gte(nrow(out), 1)
+})
+
+test_that("returns >= 1 epimutation with toy genomicratioset and method mlm", {
+	data("genomicratioset")
+	out <- epimutations(cases = genomicratioset, method = "mlm")
+	expect_gte(nrow(out), 1)
 })

--- a/tests/testthat/test_epimutations.R
+++ b/tests/testthat/test_epimutations.R
@@ -45,9 +45,8 @@ test_that("returns zero rows if bumphunter finds no bumps", {
 
 test_that("returns >= 1 epimutation for all methods with toy genomicratioset", {
 	data("genomicratioset")
-	out <- epimutations(cases = genomicratioset, method = "manova")
-	out <- epimutations(cases = genomicratioset, method = "mlm")
-	out <- epimutations(cases = genomicratioset, method = "iso.forest")
-	out <- epimutations(cases = genomicratioset, method = "Mahdist.MCD")
-	expect_gte(nrow(out), 1)
+	expect_gte(nrow(epimutations(cases = genomicratioset, method = "manova")), 1)
+	expect_gte(nrow(epimutations(cases = genomicratioset, method = "mlm")), 1)
+	expect_gte(nrow(epimutations(cases = genomicratioset, method = "iso.forest")), 1)
+	expect_gte(nrow(epimutations(cases = genomicratioset, method = "Mahdist.MCD")), 1)
 })

--- a/tests/testthat/test_epimutations.R
+++ b/tests/testthat/test_epimutations.R
@@ -43,17 +43,11 @@ test_that("returns zero rows if bumphunter finds no bumps", {
 	expect_equal(actual, 0)
 })
 
-test_that("returns >= 1 epimutation with toy genomicratioset and method manova", {
+test_that("returns >= 1 epimutation for all methods with toy genomicratioset", {
 	data("genomicratioset")
 	out <- epimutations(cases = genomicratioset, method = "manova")
 	out <- epimutations(cases = genomicratioset, method = "mlm")
 	out <- epimutations(cases = genomicratioset, method = "iso.forest")
 	out <- epimutations(cases = genomicratioset, method = "Mahdist.MCD")
-	expect_gte(nrow(out), 1)
-})
-
-test_that("returns >= 1 epimutation with toy genomicratioset and method mlm", {
-	data("genomicratioset")
-	out <- epimutations(cases = genomicratioset, method = "mlm")
 	expect_gte(nrow(out), 1)
 })


### PR DESCRIPTION
- Fixed `epiMahdist.MCD` which was missing an argument.
- Reworked unittest that checks at least one epimutation is called in `genomicratioset`.