### PR TITLE
Task1 feature beta diff

### DIFF
--- a/R/BumpBetaMatrix.R
+++ b/R/BumpBetaMatrix.R
@@ -25,3 +25,19 @@ get_betas <- function(bump, dataset) {
 	# Return transposed matrix
 	return(t(betas))
 }
+
+#' Return the average regional methylation difference between a case and controls.
+#'
+#' @param betas (matrix) The beta values. Columns are CpGs, rows are samples.
+#' @param case_id (string) The rowname in betas for the case of interest.
+#'
+#' @return (numeric) mean_beta(case) - mean_beta(controls)
+#' @keywords internal
+ave_beta_case_minus_controls <- function(betas, case_id){
+	case_row <- which(rownames(betas) %in% case_id)
+	average_betas_per_sample <- rowMeans(betas)
+	return(
+		average_betas_per_sample[case_row] - 
+			mean(average_betas_per_sample[-case_row])
+	)
+}

--- a/R/EpiMANOVA.R
+++ b/R/EpiMANOVA.R
@@ -15,22 +15,14 @@
 #' }
 #' @export
 #' 
-epi_manova <- function(betas, model, sample_id){
+epi_manova <- function(betas, model){
   
   # Fit the manova model
   mod <- manova(betas ~ model)
-  
-  # Model summary
   mod_summary <- summary(mod)$stats
   
-  # Obtain statistics (F statistic, pillai, p value)
+  # Obtain statistics (F statistic, Pillai statistic, p value)
   statistics <- mod_summary[1, c("approx F", "Pillai","Pr(>F)")]
-  
-  # Calculate the beta mean absolute difference
-  case_row <- which(rownames(betas) %in% sample_id)
-  beta_mean_difference <- mean(abs(colMeans(betas[-case_row,]) - betas[case_row,]))
 
-  output <- c(statistics, "beta_mean_abs_diff" = beta_mean_difference)
-
-  return(output)
+  return(statistics)
 }

--- a/R/EpiMutations.R
+++ b/R/EpiMutations.R
@@ -227,16 +227,16 @@ filter_bumps <- function(bumps, min_cpgs_per_bump){
 
 compute_bump_outlier_scores <- function(set, bumps, method, sample, model, nsamp){
   bumps$outlier_score <- bumps$outlier_significance <- rep(NA_real_, nrow(bumps))
-  if(method == "manova") bumps$beta_diff <- rep(NA_real_, nrow(bumps))
+  bumps$beta_diff <- rep(NA_real_, nrow(bumps))
   for(i in seq_len(nrow(bumps))) {
     betas <- get_betas(bumps[i, ], set)
+    bumps$beta_diff[i] <- ave_beta_case_minus_controls(betas, sample)
     if(method == "manova") {
         manova_has_enough_samples <- nrow(betas) >= ncol(betas) + 2
       if(manova_has_enough_samples) {
-          stats_manova <- epi_manova(betas, model, sample)
+          stats_manova <- epi_manova(betas, model)
           bumps$outlier_score[i] <- stats_manova["approx F"]
           bumps$outlier_significance[i] <- stats_manova["Pr(>F)"]
-          bumps$beta_diff[i] <- stats_manova["beta_mean_abs_diff"]
       }
     } else if(method == "mlm") {
         stats_mlm <- epiMLM(betas, model)
@@ -301,7 +301,7 @@ format_bumps <- function(bumps, set, sample, method, reduced){
 	)
 	if(reduced){
 		reduced_col <- c("sample", "chr", "start", "end", "length", "n_cpgs", "cpg_ids",
-		                 "outlier_method", "outlier_score", "outlier_significance")
+		                 "beta_diff", "outlier_method", "outlier_score", "outlier_significance")
 		df_out <- df_out[, reduced_col]
 	}
 	return(df_out)

--- a/R/EpiMutations.R
+++ b/R/EpiMutations.R
@@ -258,7 +258,7 @@ select_outlier_bumps <- function(bumps, method, pValue.cutoff, fStat_min, betaDi
         outliers <- subset(
             bumps,
             outlier_score >= fStat_min &
-                beta_diff >= betaDiff_min &
+                abs(beta_diff) >= betaDiff_min &
                 outlier_significance < pValue.cutoff 
         )
     } else if(method == "mlm"){


### PR DESCRIPTION
- The average regional methylation difference between case and controls (i.e. `beta_diff`) computation is now encapsulated in its own function.
- In the new function, the formula is corrected (average over CpGs first, then over controls).
- `epimutations` now outputs a `beta_diff` column by default.